### PR TITLE
Bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ const CLASSES = {
   OVERLAY: 'offcanvas-overlay',
   VISIBLE: 'visible',
   OPEN: 'open',
-  LOCK_OVERFLOW: 'offcanvas-is-open'
+  LOCK_OVERFLOW: 'offcanvas-is-open',
+  READY: 'offcanvas-ready'
 };
 
 const SELECTORS = {
@@ -71,6 +72,11 @@ class OffCanvas {
     // Setting up the rest
     this.setupEvents();
     this.setupTriggers(this.options.trigger);
+
+    // Making it ready to fix browser issues
+    setTimeout(() => {
+      addClass(document.body, CLASSES.READY);
+    }, this.transitionTime)
   }
 
   setupTriggers(els) {

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ class OffCanvas {
         window.getComputedStyle(this.el).transitionDuration) * 1000;
 
     this.setup();
+    this.setupEvents();
   }
 
   setupEvents() {
@@ -36,25 +37,26 @@ class OffCanvas {
   }
 
   destroy() {
-    off(window, 'resize', this.boundSetup);
-    off(window, 'orientationchange', this.boundSetup);
     off(this.overlay, 'click', this.boundHide);
 
     this.options.trigger.forEach(trigger =>
         off(trigger, 'click', this.boundSetup));
+    this.overlay.remove();
+    this.overlay = null;
+    this.initialized = false;
   }
 
   setup() {
     if (window.matchMedia && this.options.match &&
       !window.matchMedia(this.options.match).matches) {
-      if (this.initialised) {
+      if (this.initialized) {
         this.destroy();
       }
 
       return;
     }
 
-    this.initialised = true;
+    this.initialized = true;
 
     // Setting some default id for ARIA to work
     if (!this.el.id) {
@@ -64,19 +66,24 @@ class OffCanvas {
     this.updateAria();
 
     // Creating overlay
-    this.overlay = document.createElement('div');
-    addClass(this.overlay, CLASSES.OVERLAY);
-    document.body.appendChild(this.overlay);
-    on(this.overlay, 'click', this.boundHide);
+    this.setupOverlay();
 
     // Setting up the rest
-    this.setupEvents();
     this.setupTriggers(this.options.trigger);
 
     // Making it ready to fix browser issues
     setTimeout(() => {
       addClass(document.body, CLASSES.READY);
-    }, this.transitionTime)
+    }, this.transitionTime);
+  }
+
+  setupOverlay() {
+    if (!this.overlay) {
+      this.overlay = document.createElement('div');
+      addClass(this.overlay, CLASSES.OVERLAY);
+      document.body.appendChild(this.overlay);
+      on(this.overlay, 'click', this.boundHide);
+    }
   }
 
   setupTriggers(els) {

--- a/offcanvas.css
+++ b/offcanvas.css
@@ -39,7 +39,7 @@
     left: 0;
     width: 250px;
     height: 100%;
-    transform: translateX(-250px);
+    transform: translate3d(-250px, 0, 0);
     overflow-y: auto;
 }
 
@@ -48,20 +48,20 @@
     overflow-y: auto;
     right: 0;
     top: 0;
-    transform: translateX(250px);
+    transform: translate3d(250px, 0, 0);
     width: 250px;
 }
 
 .offcanvas.open {
-    transform: translate(0, 0);
+    transform: translate3d(0, 0, 0);
 }
 
 .offcanvas.left.open ~ .offcanvas-content {
-    transform: translateX(250px);
+    transform: translate3d(250px, 0, 0);
 }
 
 .offcanvas.right.open ~ .offcanvas-content {
-    transform: translateX(-250px);
+    transform: translate3d(-250px, 0, 0);
 }
 
 .offcanvas-is-open {


### PR DESCRIPTION
Opening this PR since this is odd.

I've noticed that not using `translate3d` is not an option. Makes the transition go really bad on webkit.
As for the ready class I know what you're thinking. This is however to address an iOS Safari bug which shows the layer transitioning. It only happens in some rare cases in which there might be a video. Note that hiding the video doesn't really work. So this is a small *hook* to be able to hide the offcanvas and avoid the transition to be visible.

Something like this:

```css
.offcanvas {
  visibility: hidden;
}

.offcanvas-ready .offcanvas {
  visibility: visible;
}
```

Works consistently although not desirable.